### PR TITLE
Support CoP files (non-randomized new world)

### DIFF
--- a/src/TradeGrammar.py
+++ b/src/TradeGrammar.py
@@ -100,7 +100,7 @@ nodeSection = (Literal("node").suppress() + eq + begin + \
                  pullPowerLine +
                  retainPowerLine +
                  highestPowerLine +
-                OneOrMore(powerSection).suppress() +
+                ZeroOrMore(powerSection).suppress() +
                 ZeroOrMore(incomingSection) +
                 tradegoodSection +
                 Optional(topProvincesSection) +


### PR DESCRIPTION
I noticed the trade visualizer wasn't working with my CoP save, so I investigated. 

Unfortunately I am not familiar with PyParser and do not have a non-CoP save game available for testing backwards compatibility. 
