### PR TITLE
Linux compatibility

### DIFF
--- a/src/TradeGrammar.py
+++ b/src/TradeGrammar.py
@@ -48,6 +48,7 @@ typeLine = Literal("type") + eq + integer
 actualAddedValueLine = Literal("actual_added_value").suppress() + eq + flt
 hasTraderLine = Literal("has_trader") + eq + yesno
 hasCapitalLine = Literal("has_capital") + eq + yesno
+hasSubjectLine = Literal("has_subject") + eq + yesno
 
 modifierSection = Literal("modifier") + eq + begin + \
         Literal("key") + eq + name + \
@@ -70,6 +71,7 @@ powerSection = Literal("power").suppress() + eq + begin + \
                     actualAddedValueLine +
                     hasTraderLine +
                     hasCapitalLine) + \
+                    Optional(hasSubjectLine) + \
                     Optional(modifierSection) + \
                 stop
 

--- a/src/TradeGrammar.py
+++ b/src/TradeGrammar.py
@@ -100,7 +100,7 @@ nodeSection = (Literal("node").suppress() + eq + begin + \
                  pullPowerLine +
                  retainPowerLine +
                  highestPowerLine +
-                OneOrMore(powerSection).suppress() +
+                ZeroOrMore(powerSection).suppress() +
                 ZeroOrMore(incomingSection) +
                 tradegoodSection +
                 Optional(topProvincesSection) +

--- a/src/tradeviz.py
+++ b/src/tradeviz.py
@@ -16,6 +16,7 @@ VERSION = "1.1.4"
 # DEPENDENDIES:
 # PyParsing: http://pyparsing.wikispaces.com or use 'pip install pyparsing'
 # Python Imaging Library: http://www.pythonware.com/products/pil/
+# On Ubuntu: aptitude install python-tk python-imaging python-imaging-tk python-pyparsing
 
 # standardlib stuff
 import logging
@@ -42,7 +43,7 @@ from TradeGrammar import tradeSection
 provinceBMP = "../res/worldmap.gif"
 WinRegKey = "SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App 236850"  # Win64 only...
 MacDefaultPath = os.path.expanduser("~/Library/Application Support/Steam/Steamapps/common/Europa Universalis IV")
-LinuxDefaultPath = os.path.expanduser("~/Steam/Steamapps/common/Europa Universalis IV")
+LinuxDefaultPath = os.path.expanduser("~/.local/share/Steam/SteamApps/common/Europa Universalis IV")
 
 # Colors
 LIGHT_SLATE = "#36434b"
@@ -430,8 +431,8 @@ class TradeViz:
 
         logging.debug("Getting node data")
 
-        tradenodes = r"common\tradenodes\00_tradenodes.txt"
-        positions = r"map\positions.txt"
+        tradenodes = r"common/tradenodes/00_tradenodes.txt"
+        positions = r"map/positions.txt"
 
         modPath = self.modPathComboBox.get()
         modzip = modPath.replace(".mod", ".zip")


### PR DESCRIPTION
As I was poking around the code anyway, and I have a linux box (where EU unfortunately does not run, but is installed in the default path), I decided to fix Linux compatibility of the script.

Relatively simple: 
- Fixed the default path of EU4. 
- Fixed path seperators to be a slash instead of a backslash (I have tested it on Windows, and it still works there)
- I added a comment line noting which packages you need tohttps://support.steampowered.com/kb_article.php?ref=1504-QHXN-8366 install on Ubuntu. Ubuntu is currently the only "supported" platform for Steam\* so I thought it would suffice. 
- = see https://support.steampowered.com/kb_article.php?ref=1504-QHXN-8366

PS, this is my first time using github for other things than my personal projects, so whoops apparently the other fixes are also in this pull request and I can't seem to get rid of them. 
